### PR TITLE
refactor: move the auth provider references as part of url path

### DIFF
--- a/docs/auth-providers.md
+++ b/docs/auth-providers.md
@@ -6,36 +6,30 @@ The auth gw currently supports openid connect and saml2 -type authentication flo
 
 Sinuna is an Openid Connect -type authentication provider with the following endpoints:
 
-- login: `/auth/openid/login-request`
-- token: `/auth/openid/auth-token-request`
-- userInfo: `/auth/openid/user-info-request`
-- logout: `/auth/openid/logout-request`
+- login: `/auth/openid/sinuna/login-request`
+- token: `/auth/openid/sinuna/auth-token-request`
+- userInfo: `/auth/openid/sinuna/user-info-request`
+- logout: `/auth/openid/sinuna/logout-request`
 
 The login flow gets a `loginCode` and uses it to get an access token. The access token is then used to get user info.
-
-The _provider_ reference ident for the login is: `sinuna`.
 
 ## SuomiFi
 
 SuomiFi is an SAML2 -type authentication provider with the following endpoints:
 
-- login: `/auth/saml2/login-request`
-- userInfo: `/auth/saml2/user-info-request`
-- logout: `/auth/saml2/logout-request`
+- login: `/auth/saml2/suomifi/login-request`
+- userInfo: `/auth/saml2/suomifi/user-info-request`
+- logout: `/auth/saml2/suomifi/logout-request`
 
 The login flow gets a `loginCode` which is an user identifier (nameID). The user identifier is then used to get user info.
-
-The _provider_ reference ident for the login is: `suomifi`.
 
 ## Testbed
 
 Testbed is an Openid Connect -type authentication provider with the following endpoints:
 
-- login: `/auth/openid/login-request`
-- token: `/auth/openid/auth-token-request`
-- userInfo: `/auth/openid/user-info-request`
-- logout: `/auth/openid/logout-request`
+- login: `/auth/openid/testbed/login-request`
+- token: `/auth/openid/testbed/auth-token-request`
+- userInfo: `/auth/openid/testbed/user-info-request`
+- logout: `/auth/openid/testbed/logout-request`
 
 The login flow gets a `loginCode` and uses it to get an access token and an id token. The access token is then used to get user info, the id token is used in logging out.
-
-The _provider_ reference ident for the login is: `testbed`.

--- a/openapi/authentication-gw.yml
+++ b/openapi/authentication-gw.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: "Authentication Gateway API"
-  version: 1.0.0
+  version: 1.1.0
 paths:
   "/":
     get:
@@ -36,7 +36,7 @@ paths:
               schema:
                 type: string
                 example: "OK"
-  "/auth/authorize":
+  "/authorize":
     post:
       operationId: AuthorizeRequest
       parameters:
@@ -73,23 +73,22 @@ paths:
                   message:
                     type: string
                     default: "Access Denied"
-  "/auth/openid/login-request":
+  "/auth/openid/{provider}/login-request":
     get:
       operationId: OpenIdLoginRequest
       parameters:
+        - in: path
+          description: "Auth provider ident"
+          name: provider
+          schema:
+            type: string
+          required: true
         - in: query
           name: appContext
           schema:
             type: string
           required: true
           description: "Base64-encoded object with attributes: {appName: string, redirectUrl: string}"
-        - in: query
-          name: provider
-          schema:
-            type: string
-            default: "sinuna"
-          required: false
-          description: "Auth provider name"
       responses:
         "307":
           description: Redirect to the authentication provider service
@@ -98,11 +97,16 @@ paths:
               description: Authentication provider service URL
               schema:
                 type: string
-
-  "/auth/openid/authenticate-response":
+  "/auth/openid/{provider}/authenticate-response":
     get:
       operationId: OpenIdAuthenticateResponse
       parameters:
+        - in: path
+          description: "Auth provider ident"
+          name: provider
+          schema:
+            type: string
+          required: true
         - in: query
           name: code
           description: "Login code"
@@ -148,22 +152,21 @@ paths:
               description: App context URL
               schema:
                 type: string
-  "/auth/openid/logout-request":
+  "/auth/openid/{provider}/logout-request":
     get:
       parameters:
+        - in: path
+          description: "Auth provider ident"
+          name: provider
+          schema:
+            type: string
+          required: true
         - in: query
           name: appContext
           schema:
             type: string
           required: true
           description: "Base64-encoded object with attributes: {appName: string, redirectUrl: string}"
-        - in: query
-          name: provider
-          schema:
-            type: string
-            default: "sinuna"
-          required: false
-          description: "Auth provider name"
         - in: query
           name: idToken
           schema:
@@ -179,10 +182,16 @@ paths:
               description: Authentication provider service URL
               schema:
                 type: string
-  "/auth/openid/logout-response":
+  "/auth/openid/{provider}/logout-response":
     get:
       operationId: OpenIdLogoutResponse
       parameters:
+        - in: path
+          description: "Auth provider ident"
+          name: provider
+          schema:
+            type: string
+          required: true
         - in: query
           name: state
           schema:
@@ -197,9 +206,16 @@ paths:
               description: App context URL
               schema:
                 type: string
-  "/auth/openid/auth-token-request":
+  "/auth/openid/{provider}/auth-token-request":
     post:
       operationId: OpenIdAuthTokenRequest
+      parameters:
+        - in: path
+          description: "Auth provider ident"
+          name: provider
+          schema:
+            type: string
+          required: true
       requestBody:
         description: Retrieve the authentication token from the auth provider service
         required: true
@@ -233,9 +249,16 @@ paths:
                 properties:
                   message:
                     type: string
-  "/auth/openid/user-info-request":
+  "/auth/openid/{provider}/user-info-request":
     post:
       operationId: OpenIdUserInfoRequest
+      parameters:
+        - in: path
+          description: "Auth provider ident"
+          name: provider
+          schema:
+            type: string
+          required: true
       requestBody:
         description: Retrieve user info from the auth provider service
         required: true
@@ -271,10 +294,16 @@ paths:
                 properties:
                   message:
                     type: string
-  "/auth/saml2/login-request":
+  "/auth/saml2/{provider}/login-request":
     get:
       operationId: Saml2LoginRequest
       parameters:
+        - in: path
+          description: "Auth provider ident"
+          name: provider
+          schema:
+            type: string
+          required: true
         - in: query
           name: appContext
           schema:
@@ -296,29 +325,35 @@ paths:
               description: Authentication provider service URL
               schema:
                 type: string
-  "/auth/saml2/authenticate-response":
+  "/auth/saml2/{provider}/authenticate-response":
     post:
       operationId: Saml2AuthenticateResponse
+      parameters:
+        - in: path
+          description: "Auth provider ident"
+          name: provider
+          schema:
+            type: string
+          required: true
       responses:
         "200":
           description: Handle response from the auth provider
-  "/auth/saml2/logout-request":
+  "/auth/saml2/{provider}/logout-request":
     get:
       operationId: Saml2LogoutRequest
       parameters:
+        - in: path
+          description: "Auth provider ident"
+          name: provider
+          schema:
+            type: string
+          required: true
         - in: query
           name: appContext
           schema:
             type: string
           required: true
           description: "Base64-encoded object with attributes: {appName: string, redirectUrl: string}"
-        - in: query
-          name: provider
-          schema:
-            type: string
-            default: "suomifi"
-          required: false
-          description: "Auth provider name"
       responses:
         "307":
           description: Redirect to the authentication provider service
@@ -327,10 +362,16 @@ paths:
               description: Authentication provider service URL
               schema:
                 type: string
-  "/auth/saml2/logout":
+  "/auth/saml2/{provider}/logout-response":
     get:
       operationId: Saml2LogoutResponse
       parameters:
+        - in: path
+          description: "Auth provider ident"
+          name: provider
+          schema:
+            type: string
+          required: true
         - in: query
           name: SAMLResponse
           schema:
@@ -363,9 +404,16 @@ paths:
               description: App context URL
               schema:
                 type: string
-  "/auth/saml2/user-info-request":
+  "/auth/saml2/{provider}/user-info-request":
     post:
       operationId: Saml2UserInfoRequest
+      parameters:
+        - in: path
+          description: "Auth provider ident"
+          name: provider
+          schema:
+            type: string
+          required: true
       requestBody:
         description: Retrieve user info from the auth provider service
         required: true

--- a/src/utils/route-utils.ts
+++ b/src/utils/route-utils.ts
@@ -70,12 +70,18 @@ export function InternalServerErrorHandler(error: any) {
  */
 export function resolveProvider(context: Context, defaultProvider: string | undefined) {
   let provider = defaultProvider;
-  if (context.request.query?.provider) {
+  if (context.request.params?.provider) {
+    // Url path params
+    provider = String(context.request.params.provider);
+  } else if (context.request.query?.provider) {
+    // Query params
     provider = String(context.request.query.provider);
   } else if (context.request.requestBody?.provider) {
+    // JSON body
     provider = String(context.request.requestBody.provider);
-  } else if (context.request.headers?.["x-provider"]) {
-    provider = String(context.request.headers["x-provider"]);
+  } else if (context.request.headers?.["x-authentication-provider"]) {
+    // Header
+    provider = String(context.request.headers["x-authentication-provider"]);
   } else {
     try {
       const appContext = parseAppContext(context, defaultProvider);

--- a/web/index.html
+++ b/web/index.html
@@ -53,8 +53,8 @@
         appName: "authflow-test",
         authAPIHost: "", // the authentication gw host
         authResponseHandlerUrl: window.location.origin + window.location.pathname, // the url without query params etc
-        generateAppContext(provider) {
-            return encodeURIComponent(btoa(JSON.stringify({ appName: this.appName, redirectUrl: this.authResponseHandlerUrl, provider: provider })));
+        generateAppContext() {
+            return encodeURIComponent(btoa(JSON.stringify({ appName: this.appName, redirectUrl: this.authResponseHandlerUrl })));
         },
         validateAppSettings() {
             if (!this.authAPIHost) {
@@ -97,21 +97,46 @@
 
     class BaseLoginApp {
         name = null;
-        endpoints = {
-            login: null,
-            logout: null,
-            userInfo: null,
-            token: null,
-        }
+        endpoints = null;
 
         constructor(configuration) {
             this.name = configuration.name;
-            this.endpoints = configuration.endpoints;
+            this.initializeEndpoints(configuration.name, configuration.authProtocol);
 
             this.UIState = new UIState(this);
             this.AuthState = new AuthState(this);
             this.AuthService = new AuthService(this);
         }
+
+        initializeEndpoints(providerName, authProtocol) {
+            const provider = providerName.toLowerCase();
+            const protocol = authProtocol.toLowerCase();
+            const authAPIHost = AppSettings.authAPIHost;
+
+            this.endpoints = {
+                login: null,
+                logout: null,
+                userInfo: null,
+                token: null,
+            }
+
+            switch (protocol) {
+                case "openid":
+                    this.endpoints.login = `${authAPIHost}/auth/openid/${provider}/login-request`;
+                    this.endpoints.logout = `${authAPIHost}/auth/openid/${provider}/logout-request`;
+                    this.endpoints.userInfo = `${authAPIHost}/auth/openid/${provider}/user-info-request`;
+                    this.endpoints.token = `${authAPIHost}/auth/openid/${provider}/auth-token-request`;
+                    break;
+                case "saml2":
+                    this.endpoints.login = `${authAPIHost}/auth/saml2/${provider}/login-request`;
+                    this.endpoints.logout = `${authAPIHost}/auth/saml2/${provider}/logout-request`;
+                    this.endpoints.userInfo = `${authAPIHost}/auth/saml2/${provider}/user-info-request`;
+                    break;
+                default:
+                    throw new Error(`Unknown auth protocol: ${protocol}`);
+            }
+        }
+
 
         initialize() {
             this.UIState.initialize();
@@ -182,7 +207,7 @@
         login() {
             this.log("AuthService", "logging in..");
             AppSettings.validateAppSettings();
-            this.UIState.transitToUrl(`${slashTrim(AppSettings.authAPIHost)}/${slashTrim(this.endpoints.login)}?appContext=${AppSettings.generateAppContext(this.getName())}`); // LoginRequest
+            this.UIState.transitToUrl(`${this.endpoints.login}?appContext=${AppSettings.generateAppContext()}`); // LoginRequest
         }
         async fetchAuthTokens(loginCode) {
             if (typeof this.endpoints.token !== "string") {
@@ -190,7 +215,7 @@
                 return { token: loginCode };
             }
 
-            const response = await fetch(`${slashTrim(AppSettings.authAPIHost)}/${slashTrim(this.endpoints.token)}`, { // AuthTokenRequest
+            const response = await fetch(`${this.endpoints.token}`, { // AuthTokenRequest
                 method: "POST",
                 credentials: 'include',
                 headers: {
@@ -198,7 +223,7 @@
                 },
                 body: JSON.stringify({
                     loginCode: loginCode,
-                    appContext: AppSettings.generateAppContext(this.getName()),
+                    appContext: AppSettings.generateAppContext(),
                 }),
             });
 
@@ -206,7 +231,7 @@
             return { token: data.token, idToken: data.idToken }
         }
         async fetchUserInfo(accessToken) {
-            const response = await fetch(`${slashTrim(AppSettings.authAPIHost)}/${slashTrim(this.endpoints.userInfo)}`, { // UserInfoRequest
+            const response = await fetch(`${this.endpoints.userInfo}`, { // UserInfoRequest
                 method: "POST",
                 credentials: 'include',
                 headers: {
@@ -214,7 +239,7 @@
                 },
                 body: JSON.stringify({
                     token: accessToken,
-                    appContext: AppSettings.generateAppContext(this.getName()),
+                    appContext: AppSettings.generateAppContext(),
                 }),
             });
             if (response.status !== 200) {
@@ -230,7 +255,7 @@
             AppSettings.validateAppSettings();
 
             const urlParams = new URLSearchParams({
-                appContext: AppSettings.generateAppContext(this.getName()),
+                appContext: AppSettings.generateAppContext(),
             });
 
             const { idToken } = this.AuthState.getAuthTokens();
@@ -239,7 +264,7 @@
                 urlParams.append("idToken", idToken);
             }
 
-            this.UIState.transitToUrl(`${slashTrim(AppSettings.authAPIHost)}/${slashTrim(this.endpoints.logout)}?${urlParams.toString()}`); // LogoutRequest
+            this.UIState.transitToUrl(`${this.endpoints.logout}?${urlParams.toString()}`); // LogoutRequest
         }
     }
 
@@ -344,30 +369,15 @@
     /**************************************************************************/
     const sinuna = new BaseLoginApp({
         name: "Sinuna",
-        endpoints: {
-            login: "/auth/openid/login-request",
-            logout: "/auth/openid/logout-request",
-            userInfo: "/auth/openid/user-info-request",
-            token: "/auth/openid/auth-token-request"
-        },
+        authProtocol: "openid",
     });
     const suomifi = new BaseLoginApp({
         name: "SuomiFI",
-        endpoints: {
-            login: "/auth/saml2/login-request",
-            logout: "/auth/saml2/logout-request",
-            userInfo: "/auth/saml2/user-info-request",
-        },
+        authProtocol: "saml2",
     });
-
     const testbed = new BaseLoginApp({
         name: "Testbed",
-        endpoints: {
-            login: "/auth/openid/login-request",
-            logout: "/auth/openid/logout-request",
-            userInfo: "/auth/openid/user-info-request",
-            token: "/auth/openid/auth-token-request"
-        },
+        authProtocol: "openid",
     });
     /**************************************************************************
      * 


### PR DESCRIPTION
A change in the way the authentication provider info is transported to the auth gw-app.

In examples the *sinuna* is an example authentication provider ident string

Old patterns:  
- `/auth/openid/action-path?provider=sinuna` 
-  `/auth/openid/action-path?appContext=encodeAppContext({provider: 'sinuna'})` 

New pattern:
- `/auth/openid/sinuna/action-path` 

