### PR TITLE
feat: authorize sinuna with idToken/jwks instead of userinfo accesspoint

### DIFF
--- a/docs/auth-providers.md
+++ b/docs/auth-providers.md
@@ -21,7 +21,7 @@ Sinuna is an Openid Connect -type authentication provider with the following end
     - `email`: is the user email
     - `sub` _(disrecard)_: is the sinuna service-account specific user ID
 - Data requests to external APIs that need to be authorized:
-  - `Authorization: Bearer <accessToken>`
+  - `Authorization: Bearer <idToken>`
   - `X-authorization-provider: sinuna`
 - LogoutRequest: `/auth/openid/sinuna/logout-request`
   - ends the sinuna login session

--- a/docs/frontend-app-usage.md
+++ b/docs/frontend-app-usage.md
@@ -101,12 +101,10 @@ fetch(`https://data-product-endpoint.example`, {
   headers: {
     "Content-Type": "application/json",
     Authorization: `Bearer ${idToken}`,
-    "X-authorization-provider": "testbed",
+    "X-authorization-provider": "sinuna",
   },
 });
 ```
-
-Excemption to the `idToken` - usage is the sinuna provider which uses the `accessToken` for the same purpose.
 
 ```
 fetch(`https://data-product-endpoint.example`, {

--- a/src/providers/sinuna/SinunaAuthorizer.ts
+++ b/src/providers/sinuna/SinunaAuthorizer.ts
@@ -1,24 +1,28 @@
-import axios from "axios";
-import { AccessDeniedException } from "../../utils/exceptions";
-import { debug, logAxiosException } from "../../utils/logging";
-import { leftTrim } from "../../utils/transformers";
+import * as jwt from "jsonwebtoken";
 
+import { AccessDeniedException } from "../../utils/exceptions";
+import { debug } from "../../utils/logging";
+import { getPublicKey } from "../../utils/openId-JWKS";
+import { leftTrim } from "../../utils/transformers";
 /**
  *
- * @param accessToken
+ * @param idToken
  * @param context - which app source is requesting access
  */
-export default async function authorize(accessToken: string, context: string): Promise<void> {
+export default async function authorize(idToken: string, context: string): Promise<void> {
   try {
-    const response = await axios.get(`https://login.iam.qa.sinuna.fi/oxauth/restv1/userinfo`, {
-      headers: {
-        Authorization: `Bearer ${leftTrim(accessToken, "Bearer ")}`,
-      },
-    });
+    // Decode token
+    const token = leftTrim(idToken, "Bearer ");
+    const decodedToken = jwt.decode(token, { complete: true });
 
-    debug(response.data);
+    // Validate token
+    const publicKey = await getPublicKey(decodedToken, {
+      issuer: "https://login.iam.qa.sinuna.fi",
+      openIdConfigUrl: "https://login.iam.qa.sinuna.fi/oxauth/.well-known/openid-configuration",
+    });
+    const verified = jwt.verify(token, publicKey.pem, { ignoreExpiration: false });
+    debug(verified);
   } catch (error) {
-    logAxiosException(error);
     throw new AccessDeniedException(String(error));
   }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -232,17 +232,13 @@
         }
         async authorize() {
             this.log("AuthService", "authorizing..");
-            const { idToken, accessToken } = this.AuthState.getAuthTokens();
-            let authorizationToken = idToken;
-            if (this.getName() === "Sinuna") { // The sinuna exception
-                authorizationToken = accessToken;
-            }
+            const { idToken } = this.AuthState.getAuthTokens();
 
             const response = await fetch(`${this.endpoints.AuthorizeRequest}`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    Authorization: `Bearer ${authorizationToken}`,
+                    Authorization: `Bearer ${idToken}`,
                     "X-authorization-provider": this.getName(),
                     "X-Authorization-Context": "demo app",
                 },

--- a/web/index.html
+++ b/web/index.html
@@ -232,13 +232,17 @@
         }
         async authorize() {
             this.log("AuthService", "authorizing..");
-            const { idToken } = this.AuthState.getAuthTokens();
+            const { idToken, accessToken } = this.AuthState.getAuthTokens();
+            let authorizationToken = idToken;
+            if (this.getName() === "Sinuna") { // The sinuna exception
+                authorizationToken = accessToken;
+            }
 
             const response = await fetch(`${this.endpoints.AuthorizeRequest}`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",
-                    Authorization: `Bearer ${idToken}`,
+                    Authorization: `Bearer ${authorizationToken}`,
                     "X-authorization-provider": this.getName(),
                     "X-Authorization-Context": "demo app",
                 },


### PR DESCRIPTION
Remove the sinuna specific need to authorize using `accessKey`:
- use `idToken` instead by verifyng against the sinuna jwks-endpoint provided public key

Depends on [PR](https://github.com/Virtual-Finland-Development/testbed-test-front/pull/3)