### PR TITLE
VFD-127-tiputetaan-auth-provider-header-pois-vaatimuksista

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ const response = await fetch(`${authentication_gw_host}/authorize`, {
   headers: {
     "Content-Type": "application/json",
     Authorization: `Bearer <idToken>`,
-    "X-authorization-provider": "sinuna",
     "X-Authorization-Context": "demo productizer app",
   },
 });

--- a/docs/auth-providers.md
+++ b/docs/auth-providers.md
@@ -19,7 +19,6 @@ Sinuna is an Openid Connect -type authentication provider with the following end
         - `email`: is the user email
 - Data requests to external APIs that need to be authorized:
   - `Authorization: Bearer <idToken>`
-  - `X-authorization-provider: sinuna`
 - LogoutRequest: `/auth/openid/sinuna/logout-request`
   - ends the sinuna login session
 
@@ -45,7 +44,6 @@ SuomiFi is an SAML2 -type authentication provider with the following endpoints:
         - `context.AuthnContextClassRef`: the authentication level reference
 - Data requests to external APIs that need to be authorized:
   - `Authorization: Bearer <idToken>`
-  - `X-authorization-provider: suomifi`
 - LogoutRequest: `/auth/saml2/suomifi/logout-request`
   - ends the suomifi login session
 
@@ -70,7 +68,6 @@ Testbed is an Openid Connect -type authentication provider with the following en
         - `email`: is the user testbed-email
 - Data requests to external APIs that need to be authorized:
   - `Authorization: Bearer <idToken>`
-  - `X-authorization-provider: testbed`
 - LogoutRequest: `/auth/openid/testbed/logout-request`
   - uses the `idToken` to end the testbed login session
 

--- a/docs/frontend-app-usage.md
+++ b/docs/frontend-app-usage.md
@@ -106,7 +106,7 @@ localStorage.setItem(`idToken_sinuna`, idToken);
 
 ## Using the auth token
 
-Requests to the protected external backend services are accompanied with the `idToken` as a bearer token in the `Authorization` header, accomppanied with a provider name in the `X-authorization-provider` header.
+Requests to the protected external backend services are accompanied with the `idToken` as a bearer token in the `Authorization` header.
 
 eg:
 
@@ -116,7 +116,6 @@ fetch(`https://data-product-endpoint.example`, {
   headers: {
     "Content-Type": "application/json",
     Authorization: `Bearer ${idToken}`,
-    "X-authorization-provider": "sinuna",
   },
 });
 ```

--- a/openapi/authentication-gw.yml
+++ b/openapi/authentication-gw.yml
@@ -47,12 +47,6 @@ paths:
           schema:
             type: string
         - in: header
-          name: X-Authorization-Provider
-          required: true
-          description: "Authentication provider ident, or id_token issuer field"
-          schema:
-            type: string
-        - in: header
           name: X-Authorization-Context
           required: false
           description: "Optional usage context"

--- a/src/routes/BaseRoutes.ts
+++ b/src/routes/BaseRoutes.ts
@@ -25,9 +25,8 @@ export default {
    */
   async AuthorizeRequest(context: Context): Promise<HttpResponse> {
     const authorization = context.request.headers.authorization;
-    const authorizationProvider = context.request.headers["x-authorization-provider"];
     const authorizationContext = context.request.headers["x-authorization-context"];
-    await Authorizator.authorize(authorization, authorizationProvider, authorizationContext); // Throws AccessDeniedException if access needs to be denied
+    await Authorizator.authorize(authorization, authorizationContext); // Throws AccessDeniedException if access needs to be denied
 
     return {
       statusCode: 200,

--- a/webapps/simple/index.html
+++ b/webapps/simple/index.html
@@ -218,7 +218,6 @@
                 headers: {
                     "Content-Type": "application/json",
                     Authorization: `Bearer ${idToken}`,
-                    "X-authorization-provider": this.getName(),
                     "X-Authorization-Context": "demo app",
                 },
             });

--- a/webapps/svelte/src/lib/api/openapi/generated/services/DefaultService.ts
+++ b/webapps/svelte/src/lib/api/openapi/generated/services/DefaultService.ts
@@ -50,17 +50,12 @@ export class DefaultService {
      */
     public authorizeRequest({
         authorization,
-        xAuthorizationProvider,
         xAuthorizationContext,
     }: {
         /**
          * id_token as a bearer header
          */
         authorization: string,
-        /**
-         * Authentication provider ident, or id_token issuer field
-         */
-        xAuthorizationProvider: string,
         /**
          * Optional usage context
          */
@@ -73,7 +68,6 @@ export class DefaultService {
             url: '/authorize',
             headers: {
                 'Authorization': authorization,
-                'X-Authorization-Provider': xAuthorizationProvider,
                 'X-Authorization-Context': xAuthorizationContext,
             },
             errors: {


### PR DESCRIPTION
- drop the unsupported x-authentication-provider header requirement
- resolve the provider from the jwt payload