### PR TITLE
feat: use new testbed api-route on the testbed consent proxying

### DIFF
--- a/openapi/authentication-gw.yml
+++ b/openapi/authentication-gw.yml
@@ -72,29 +72,6 @@ paths:
                   message:
                     type: string
                     default: "Access Denied"
-  "/testbed-reverse-proxy":
-    post:
-      operationId: TestbedReverseProxy
-      requestBody:
-        description: Request contents
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required: ["method", "url"]
-              properties:
-                method:
-                  type: string
-                url:
-                  type: string
-                data:
-                  type: object
-                headers:
-                  type: object
-      responses:
-        "200":
-          description: Response data
   "/consent/testbed/verify":
     post:
       operationId: TestbedConsentVerify

--- a/webapps/svelte/src/AppSettings.ts
+++ b/webapps/svelte/src/AppSettings.ts
@@ -1,4 +1,5 @@
 export default {
   appName: "authflow-test",
   authenticationGatewayHost: "http://localhost:3000",
+  testbedAPIHost: "http://localhost:3003",
 };

--- a/webapps/svelte/src/lib/api/ConsentAPI.ts
+++ b/webapps/svelte/src/lib/api/ConsentAPI.ts
@@ -13,7 +13,7 @@ export default class ConsentAPI {
   async getConsentSituation(consentId: string, idToken: string, returnUrl?: string): Promise<ConsentSituation> {
     // Request the consent: https://ioxio.com/guides/how-to-build-an-application#request-consent
     try {
-      const response = await axios.post(`${AppSettings.authenticationGatewayHost}/testbed-reverse-proxy`, {
+      const response = await axios.post(`${AppSettings.testbedAPIHost}/testbed/reverse-proxy`, {
         method: "POST",
         url: `https://consent.testbed.fi/Consent/Request`,
         data: {
@@ -60,7 +60,7 @@ export default class ConsentAPI {
    */
   async testConsentIdRequest(dataSourceUrl: string, inputData: any, consentToken: string, idToken: string): Promise<any> {
     // Test with a request: https://ioxio.com/guides/how-to-build-an-application#using-the-consent-token
-    const response = await axios.post(`${AppSettings.authenticationGatewayHost}/testbed-reverse-proxy`, {
+    const response = await axios.post(`${AppSettings.testbedAPIHost}/testbed/reverse-proxy`, {
       method: "POST",
       url: dataSourceUrl,
       data: inputData,

--- a/webapps/svelte/src/lib/api/openapi/generated/services/DefaultService.ts
+++ b/webapps/svelte/src/lib/api/openapi/generated/services/DefaultService.ts
@@ -23,16 +23,13 @@ export class DefaultService {
     }
 
     /**
-     * @returns void
+     * @returns string Swagger API documentation
      * @throws ApiError
      */
-    public swagger(): CancelablePromise<void> {
+    public swagger(): CancelablePromise<string> {
         return this.httpRequest.request({
             method: 'GET',
-            url: '/swagger',
-            errors: {
-                303: `Redirect to the API documentation`,
-            },
+            url: '/docs',
         });
     }
 
@@ -73,31 +70,6 @@ export class DefaultService {
             errors: {
                 401: `Access denied message`,
             },
-        });
-    }
-
-    /**
-     * @returns any Response data
-     * @throws ApiError
-     */
-    public testbedReverseProxy({
-        requestBody,
-    }: {
-        /**
-         * Request contents
-         */
-        requestBody: {
-            method: string;
-            url: string;
-            data?: any;
-            headers?: any;
-        },
-    }): CancelablePromise<any> {
-        return this.httpRequest.request({
-            method: 'POST',
-            url: '/testbed-reverse-proxy',
-            body: requestBody,
-            mediaType: 'application/json',
         });
     }
 
@@ -169,6 +141,8 @@ export class DefaultService {
         sessionState,
         sid,
         nonce,
+        error,
+        errorDescription,
     }: {
         /**
          * Auth provider ident
@@ -177,16 +151,18 @@ export class DefaultService {
         /**
          * Login code
          */
-        code: string,
+        code?: string,
         /**
          * Login state string
          */
-        state: string,
+        state?: string,
         acrValues?: string,
         scope?: string,
         sessionState?: string,
         sid?: string,
         nonce?: string,
+        error?: string,
+        errorDescription?: string,
     }): CancelablePromise<void> {
         return this.httpRequest.request({
             method: 'GET',
@@ -202,6 +178,8 @@ export class DefaultService {
                 'session_state': sessionState,
                 'sid': sid,
                 'nonce': nonce,
+                'error': error,
+                'error_description': errorDescription,
             },
             errors: {
                 303: `Authentication providers callback url, redirect back to the app context, provide loginCode and provider -variables as query params`,


### PR DESCRIPTION
demo web app use the testbed-api as its dependency instead of local implementation