### PR TITLE
refactor: dynamically generate route operation-handler mappings

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,10 +1,8 @@
 import { APIGatewayProxyEventV2, Context as APIGatewayContext } from "aws-lambda";
 import OpenAPIBackend from "openapi-backend";
 
+import AppRoutes from "./routes/AppRoutes";
 import BaseRoutes from "./routes/BaseRoutes";
-import OpenIdAuthRoutes from "./routes/OpenidAuthRoutes";
-import TestbedConsentRoutes from "./routes/providers/testbed/TestbedConsentRoutes";
-import Saml2AuthRoutes from "./routes/Saml2AuthRoutes";
 
 import { getCORSHeaders } from "./utils/default-headers";
 import { debug, log } from "./utils/logging";
@@ -29,9 +27,7 @@ const api = new OpenAPIBackend({
 
 // register your framework specific request handlers here
 api.register({
-  ...OpenIdAuthRoutes,
-  ...Saml2AuthRoutes,
-  ...TestbedConsentRoutes,
+  ...AppRoutes,
   ...BaseRoutes,
 });
 

--- a/src/providers/testbed/TestbedConsentRequestsHandler.ts
+++ b/src/providers/testbed/TestbedConsentRequestsHandler.ts
@@ -12,7 +12,7 @@ import { fetchConsentStatus } from "./service/ConsentRequests";
 import TestbedConfig from "./Testbed.config";
 import { verifyConsent } from "./TestbedAuthorizer";
 
-export default new (class TestbedConsentsHandler extends BaseRequestHandler {
+export default new (class TestbedConsentRequestsHandler extends BaseRequestHandler {
   identityProviderIdent = TestbedConfig.ident;
 
   /**

--- a/src/routes/AppRoutes.ts
+++ b/src/routes/AppRoutes.ts
@@ -1,0 +1,23 @@
+import SinunaRequestHandler from "../providers/sinuna/SinunaRequestHandler";
+import SuomiFIRequestHandler from "../providers/suomifi/SuomiFIRequestHandler";
+import TestbedConsentRequestsHandler from "../providers/testbed/TestbedConsentRequestsHandler";
+import TestbedRequestHandler from "../providers/testbed/TestbedRequestHandler";
+
+import RouteMapper from "../utils/RouteMapper";
+
+RouteMapper.initialize([
+  {
+    operationPrefix: "OpenId",
+    handlers: [SinunaRequestHandler, TestbedRequestHandler],
+  },
+  {
+    operationPrefix: "Saml2",
+    handlers: [SuomiFIRequestHandler],
+  },
+  {
+    operationPrefix: "",
+    handlers: [TestbedConsentRequestsHandler],
+  },
+]);
+
+export default RouteMapper.getOperations();

--- a/src/routes/OpenidAuthRoutes.ts
+++ b/src/routes/OpenidAuthRoutes.ts
@@ -1,8 +1,0 @@
-import SinunaSettings from "../providers/sinuna/Sinuna.config";
-import { generateRouteRequestHandlers } from "../utils/route-utils";
-
-const defaultAuthProviderIdent = SinunaSettings.ident;
-const operationPrefix = "OpenId";
-const operationNames = ["AuthenticationRequest", "AuthenticateResponse", "LoginRequest", "LogoutRequest", "LogoutResponse"];
-
-export default generateRouteRequestHandlers(operationNames, operationPrefix, defaultAuthProviderIdent);

--- a/src/routes/Saml2AuthRoutes.ts
+++ b/src/routes/Saml2AuthRoutes.ts
@@ -1,8 +1,0 @@
-import SuomiFISettings from "../providers/suomifi/SuomiFI.config";
-import { generateRouteRequestHandlers } from "../utils/route-utils";
-
-const defaultAuthProviderIdent = SuomiFISettings.ident;
-const operationPrefix = "Saml2";
-const operationNames = ["AuthenticationRequest", "AuthenticateResponse", "LoginRequest", "LogoutRequest", "LogoutResponse", "WellKnownJWKSRequest"];
-
-export default generateRouteRequestHandlers(operationNames, operationPrefix, defaultAuthProviderIdent);

--- a/src/routes/providers/testbed/TestbedConsentRoutes.ts
+++ b/src/routes/providers/testbed/TestbedConsentRoutes.ts
@@ -1,8 +1,0 @@
-import TestbedConsentRequestsHandler from "../../../providers/testbed/TestbedConsentRequestsHandler";
-import { generateRouteRequestHandlers } from "../../../utils/route-utils";
-export default generateRouteRequestHandlers(
-  ["TestbedConsentVerify", "TestbedConsentCheck", "TestbedConsentRequest", "TestbedConsentResponse"], // @TODO: dynamically generate this
-  "",
-  undefined,
-  TestbedConsentRequestsHandler
-);

--- a/src/utils/BaseRequestHandler.ts
+++ b/src/utils/BaseRequestHandler.ts
@@ -3,10 +3,10 @@ import { Context } from "openapi-backend";
 import { AccessDeniedException, NoticeException } from "./exceptions";
 import { debug } from "./logging";
 import { prepareCookie, prepareLoginErrorRedirectUrl, prepareLogoutErrorRedirectUrl } from "./route-utils";
-import { HttpResponse, NotifyErrorType } from "./types";
+import { HttpResponse, IBaseRequestHandler, NotifyErrorType } from "./types";
 import { parseAppContext } from "./validators";
 
-export abstract class BaseRequestHandler {
+export abstract class BaseRequestHandler implements IBaseRequestHandler {
   abstract identityProviderIdent: string;
 
   /**

--- a/src/utils/RouteMapper.ts
+++ b/src/utils/RouteMapper.ts
@@ -1,0 +1,59 @@
+import { Context } from "openapi-backend";
+import { debug } from "./logging";
+import { resolveProvider } from "./route-utils";
+import { HttpResponse, IBaseRequestHandler } from "./types";
+
+const operationMap: Record<string, (context: Context) => Promise<HttpResponse>> = {};
+const handlerMap: Record<string, IBaseRequestHandler> = {};
+
+function resolveRequestHandler(operationName: string, context: Context, defaultProvider: string): IBaseRequestHandler {
+  const provider = resolveProvider(context, defaultProvider);
+  const requestHandler = handlerMap[`${provider}::${operationName}`];
+  if (!requestHandler) {
+    throw new Error(`No request handler found for provider ${provider}`);
+  }
+  return requestHandler;
+}
+
+function generateOperation(operationName: string, provider: string): (context: Context) => Promise<HttpResponse> {
+  return async (context: Context) => {
+    const requestHandler = resolveRequestHandler(operationName, context, provider);
+    await requestHandler.initialize();
+    const response = await requestHandler[operationName](context);
+    debug("Response", response);
+    return response;
+  };
+}
+
+/**
+ * Maps the request handlers and generates operations mapping
+ *
+ * @param handlerGroups
+ */
+function initialize(handlerGroups: Array<{ handlers: Array<IBaseRequestHandler>; operationPrefix: string }>): void {
+  const baseRequestHandlerMethods = ["constructor", "initialize", "getAuthenticateResponseFailedResponse", "getLogoutRequestFailedResponse"];
+
+  for (const { handlers: requestsHandlers, operationPrefix } of handlerGroups) {
+    for (const requestHandler of requestsHandlers) {
+      const operationNames = Object.getOwnPropertyNames(Object.getPrototypeOf(requestHandler)).filter(
+        (operationName) => !baseRequestHandlerMethods.includes(operationName) && typeof requestHandler[operationName] === "function"
+      );
+      const provider = requestHandler.identityProviderIdent.toLowerCase();
+
+      for (const operationName of operationNames) {
+        handlerMap[`${provider}::${operationName}`] = requestHandler; // Attach reference to handler
+        operationMap[`${operationPrefix}${operationName}`] = generateOperation(operationName, provider); // operation template function
+      }
+    }
+  }
+}
+
+/**
+ *
+ * @returns
+ */
+function getOperations(): Record<string, (context: Context) => Promise<HttpResponse>> {
+  return operationMap;
+}
+
+export default { initialize, getOperations };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -93,3 +93,11 @@ export type AuthorizationHeaders = {
   context?: string;
   consentToken?: string;
 };
+
+export interface IBaseRequestHandler {
+  identityProviderIdent: string;
+  initialize(): Promise<void>;
+  getAuthenticateResponseFailedResponse(context: Context, error: any): Promise<HttpResponse>;
+  getLogoutRequestFailedResponse(context: Context | string, error: any, errorTypeOverride?: NotifyErrorType): Promise<HttpResponse>;
+  [attr: string]: any;
+}


### PR DESCRIPTION
- change the request handler -> openapi-backend -operation mapping so that the handler methods are produced dynamically instead of static naming