### PR TITLE
Feat/add token payloads to authorize

### DIFF
--- a/openapi/swagger.yml
+++ b/openapi/swagger.yml
@@ -69,6 +69,10 @@ paths:
                   message:
                     type: string
                     default: "Access Granted"
+                  authorization:
+                    type: object
+                  consent:
+                    type: object
         "401":
           description: Access denied message
           content:

--- a/openapi/swagger.yml
+++ b/openapi/swagger.yml
@@ -65,10 +65,11 @@ paths:
             application/json:
               schema:
                 type: object
+                required: [message, authorization]
                 properties:
                   message:
                     type: string
-                    default: "Access Granted"
+                    default: "Access granted"
                   authorization:
                     type: object
                   consent:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "aws-sdk": "^2.1214.0",
         "axios": "^0.27.2",
-        "jsonwebtoken": "^8.5.1",
+        "jsonwebtoken": "^9.0.0",
         "jwk-to-pem": "^2.0.5",
         "node-saml": "^4.0.0-beta.2",
         "openapi-backend": "^5.5.0",
@@ -21,7 +21,7 @@
         "@pulumi/aws": "^5.14.0",
         "@pulumi/pulumi": "^3.40.0",
         "@types/aws-lambda": "^8.10.102",
-        "@types/jsonwebtoken": "^8.5.9",
+        "@types/jsonwebtoken": "^9.0.1",
         "@types/jwk-to-pem": "^2.0.1",
         "@types/node": "^18.7.15",
         "@types/uuid": "^8.3.4",
@@ -2615,9 +2615,9 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "node_modules/@types/jsonwebtoken": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz",
-      "integrity": "sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
+      "integrity": "sha512-c5ltxazpWabia/4UzhIoaDcIza4KViOQhdbjRlfcIGVnsE3c3brkz9Z+F/EeJIECOQP7W7US2hNE930cWWkPiw==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -6314,9 +6314,9 @@
       "peer": true
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "node_modules/http2-wrapper": {
@@ -8029,32 +8029,18 @@
       }
     },
     "node_modules/jsonwebtoken": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+      "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
       "dependencies": {
         "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
+        "lodash": "^4.17.21",
         "ms": "^2.1.1",
-        "semver": "^5.6.0"
+        "semver": "^7.3.8"
       },
       "engines": {
-        "node": ">=4",
-        "npm": ">=1.4.28"
-      }
-    },
-    "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
+        "node": ">=12",
+        "npm": ">=6"
       }
     },
     "node_modules/jszip": {
@@ -8296,35 +8282,11 @@
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true
     },
-    "node_modules/lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
-    },
-    "node_modules/lodash.isboolean": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
-    },
-    "node_modules/lodash.isinteger": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
-    },
-    "node_modules/lodash.isnumber": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
-    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
-    },
-    "node_modules/lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -8336,11 +8298,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "node_modules/lodash.once": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "node_modules/lodash.union": {
       "version": "4.6.0",
@@ -8420,7 +8377,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -10323,10 +10279,9 @@
       "dev": true
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -10579,9 +10534,9 @@
       "dev": true
     },
     "node_modules/simple-git": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.15.1.tgz",
-      "integrity": "sha512-73MVa5984t/JP4JcQt0oZlKGr42ROYWC3BcUZfuHtT3IHKPspIvL0cZBnvPXF7LL3S/qVeVHVdYYmJ3LOTw4Rg==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.16.0.tgz",
+      "integrity": "sha512-zuWYsOLEhbJRWVxpjdiXl6eyAyGo/KzVW+KFhhw9MqEEJttcq+32jTWSGyxTdf9e/YCohxRE+9xpWFj9FdiJNw==",
       "dev": true,
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
@@ -11926,8 +11881,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml-ast-parser": {
       "version": "0.0.43",
@@ -14283,9 +14237,9 @@
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "@types/jsonwebtoken": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.9.tgz",
-      "integrity": "sha512-272FMnFGzAVMGtu9tkr29hRL6bZj4Zs1KZNeHLnKqAvp06tAIcarTMwOh8/8bz4FmKRcMxZhZNeUAQsNLoiPhg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz",
+      "integrity": "sha512-c5ltxazpWabia/4UzhIoaDcIza4KViOQhdbjRlfcIGVnsE3c3brkz9Z+F/EeJIECOQP7W7US2hNE930cWWkPiw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -17074,9 +17028,9 @@
       "peer": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
       "dev": true
     },
     "http2-wrapper": {
@@ -18348,27 +18302,14 @@
       "dev": true
     },
     "jsonwebtoken": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+      "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
       "requires": {
         "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
+        "lodash": "^4.17.21",
         "ms": "^2.1.1",
-        "semver": "^5.6.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        }
+        "semver": "^7.3.8"
       }
     },
     "jszip": {
@@ -18592,35 +18533,11 @@
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true
     },
-    "lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
-    },
-    "lodash.isboolean": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
-    },
-    "lodash.isinteger": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
-    },
-    "lodash.isnumber": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
-    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
-    },
-    "lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -18632,11 +18549,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "lodash.once": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
     },
     "lodash.union": {
       "version": "4.6.0",
@@ -18701,7 +18613,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -20092,10 +20003,9 @@
       }
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-      "dev": true,
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -20287,9 +20197,9 @@
       "dev": true
     },
     "simple-git": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.15.1.tgz",
-      "integrity": "sha512-73MVa5984t/JP4JcQt0oZlKGr42ROYWC3BcUZfuHtT3IHKPspIvL0cZBnvPXF7LL3S/qVeVHVdYYmJ3LOTw4Rg==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.16.0.tgz",
+      "integrity": "sha512-zuWYsOLEhbJRWVxpjdiXl6eyAyGo/KzVW+KFhhw9MqEEJttcq+32jTWSGyxTdf9e/YCohxRE+9xpWFj9FdiJNw==",
       "dev": true,
       "requires": {
         "@kwsites/file-exists": "^1.1.1",
@@ -21287,8 +21197,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml-ast-parser": {
       "version": "0.0.43",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "aws-sdk": "^2.1214.0",
     "axios": "^0.27.2",
-    "jsonwebtoken": "^8.5.1",
+    "jsonwebtoken": "^9.0.0",
     "jwk-to-pem": "^2.0.5",
     "node-saml": "^4.0.0-beta.2",
     "openapi-backend": "^5.5.0",
@@ -37,7 +37,7 @@
     "@pulumi/aws": "^5.14.0",
     "@pulumi/pulumi": "^3.40.0",
     "@types/aws-lambda": "^8.10.102",
-    "@types/jsonwebtoken": "^8.5.9",
+    "@types/jsonwebtoken": "^9.0.1",
     "@types/jwk-to-pem": "^2.0.1",
     "@types/node": "^18.7.15",
     "@types/uuid": "^8.3.4",

--- a/src/providers/sinuna/SinunaAuthorizer.ts
+++ b/src/providers/sinuna/SinunaAuthorizer.ts
@@ -1,7 +1,7 @@
 import { AccessDeniedException } from "../../utils/exceptions";
 import { verifyIdToken } from "../../utils/JWK-Utils";
 import { debug } from "../../utils/logging";
-import { AuthorizationHeaders } from "../../utils/types";
+import { AuthorizationHeaders, AuthorizerResponse } from "../../utils/types";
 import SinunaConfig from "./Sinuna.config";
 
 export function isMatchingProvider(provider: string): boolean {
@@ -12,7 +12,7 @@ export function isMatchingProvider(provider: string): boolean {
  *
  * @param authorizationHeaders
  */
-export async function authorize(authorizationHeaders: AuthorizationHeaders): Promise<void> {
+export async function authorize(authorizationHeaders: AuthorizationHeaders): Promise<AuthorizerResponse> {
   try {
     // Verify token
     const verified = await verifyIdToken(authorizationHeaders.authorization, {
@@ -20,6 +20,11 @@ export async function authorize(authorizationHeaders: AuthorizationHeaders): Pro
       openIdConfigUrl: "https://login.iam.qa.sinuna.fi/oxauth/.well-known/openid-configuration",
     });
     debug(verified);
+
+    return {
+      authorization: verified,
+      consent: null,
+    };
   } catch (error) {
     throw new AccessDeniedException(String(error));
   }

--- a/src/providers/sinuna/SinunaAuthorizer.ts
+++ b/src/providers/sinuna/SinunaAuthorizer.ts
@@ -22,8 +22,8 @@ export async function authorize(authorizationHeaders: AuthorizationHeaders): Pro
     debug(verified);
 
     return {
+      message: "Access granted",
       authorization: verified,
-      consent: null,
     };
   } catch (error) {
     throw new AccessDeniedException(String(error));

--- a/src/providers/suomifi/SuomiFIAuthorizer.ts
+++ b/src/providers/suomifi/SuomiFIAuthorizer.ts
@@ -135,8 +135,8 @@ export async function authorize(authorizationHeaders: AuthorizationHeaders): Pro
     }
 
     return {
+      message: "Access granted",
       authorization: verified,
-      consent: null,
     };
   } catch (error) {
     debug(error);

--- a/src/providers/suomifi/SuomiFIAuthorizer.ts
+++ b/src/providers/suomifi/SuomiFIAuthorizer.ts
@@ -10,7 +10,7 @@ import { JWKS, verifyIdToken } from "../../utils/JWK-Utils";
 import { debug } from "../../utils/logging";
 import Settings from "../../utils/Settings";
 import { transformExpiresInToExpiresAt_ISOString } from "../../utils/transformers";
-import { AuthorizationHeaders, ParsedAppContext } from "../../utils/types";
+import { AuthorizationHeaders, AuthorizerResponse, ParsedAppContext } from "../../utils/types";
 import { parseAppContext } from "../../utils/validators";
 import { resolveSuomiFiUserIdFromProfileData } from "./service/SuomifiStateTools";
 import { SuomiFiProfile } from "./service/SuomifiTypes";
@@ -122,7 +122,7 @@ export function isMatchingProvider(provider: string): boolean {
  *
  * @param authorizationHeaders
  */
-export async function authorize(authorizationHeaders: AuthorizationHeaders): Promise<void> {
+export async function authorize(authorizationHeaders: AuthorizationHeaders): Promise<AuthorizerResponse> {
   try {
     // Verify token
     const verified = await verifyIdToken(authorizationHeaders.authorization, { issuer: SUOMIFI_ISSUER, jwks: await getJKWSJsonConfiguration() });
@@ -133,6 +133,11 @@ export async function authorize(authorizationHeaders: AuthorizationHeaders): Pro
     if (nonce !== verified.nonce) {
       throw new AccessDeniedException("Invalid authorizing context secret");
     }
+
+    return {
+      authorization: verified,
+      consent: null,
+    };
   } catch (error) {
     debug(error);
     throw new AccessDeniedException(String(error));

--- a/src/providers/testbed/TestbedAuthorizer.ts
+++ b/src/providers/testbed/TestbedAuthorizer.ts
@@ -20,8 +20,8 @@ export function isMatchingProvider(provider: string): boolean {
  */
 export async function authorize(authorizationHeaders: AuthorizationHeaders): Promise<AuthorizerResponse> {
   const response: AuthorizerResponse = {
+    message: "Access denied",
     authorization: null,
-    consent: null,
   };
 
   try {
@@ -31,6 +31,8 @@ export async function authorize(authorizationHeaders: AuthorizationHeaders): Pro
       openIdConfigUrl: "https://login.testbed.fi/.well-known/openid-configuration",
     });
     debug(verified);
+
+    response.message = "Access granted";
     response.authorization = verified;
   } catch (error) {
     throw new AccessDeniedException(String(error));
@@ -57,6 +59,6 @@ export async function verifyConsent(consentToken: string): Promise<JwtPayload> {
     return verified;
   } catch (error) {
     debug(error);
-    throw new AccessDeniedException("Unverified");
+    throw new AccessDeniedException("Consent unverified");
   }
 }

--- a/src/providers/testbed/TestbedAuthorizer.ts
+++ b/src/providers/testbed/TestbedAuthorizer.ts
@@ -1,7 +1,8 @@
+import { JwtPayload } from "jsonwebtoken";
 import { AccessDeniedException } from "../../utils/exceptions";
 import { verifyIdToken } from "../../utils/JWK-Utils";
 import { debug } from "../../utils/logging";
-import { AuthorizationHeaders } from "../../utils/types";
+import { AuthorizationHeaders, AuthorizerResponse } from "../../utils/types";
 import TestbedConfig from "./Testbed.config";
 
 /**
@@ -17,7 +18,12 @@ export function isMatchingProvider(provider: string): boolean {
  * @see: https://ioxio.com/guides/verify-id-token-in-a-data-source
  * @param authorizationHeaders
  */
-export async function authorize(authorizationHeaders: AuthorizationHeaders): Promise<void> {
+export async function authorize(authorizationHeaders: AuthorizationHeaders): Promise<AuthorizerResponse> {
+  const response: AuthorizerResponse = {
+    authorization: null,
+    consent: null,
+  };
+
   try {
     // Verify token
     const verified = await verifyIdToken(authorizationHeaders.authorization, {
@@ -25,14 +31,17 @@ export async function authorize(authorizationHeaders: AuthorizationHeaders): Pro
       openIdConfigUrl: "https://login.testbed.fi/.well-known/openid-configuration",
     });
     debug(verified);
+    response.authorization = verified;
   } catch (error) {
     throw new AccessDeniedException(String(error));
   }
 
   // Verify consent if requested
   if (authorizationHeaders.consentToken) {
-    await verifyConsent(authorizationHeaders.consentToken);
+    response.consent = await verifyConsent(authorizationHeaders.consentToken);
   }
+
+  return response;
 }
 
 /**
@@ -40,11 +49,12 @@ export async function authorize(authorizationHeaders: AuthorizationHeaders): Pro
  * @param consentToken
  * @see: https://ioxio.com/guides/verify-consent-in-a-data-source
  */
-export async function verifyConsent(consentToken: string): Promise<void> {
+export async function verifyConsent(consentToken: string): Promise<JwtPayload> {
   try {
     // Verify token
     const verified = await verifyIdToken(consentToken, { issuer: "https://consent.testbed.fi", jwksUri: "https://consent.testbed.fi/.well-known/jwks.json" });
     debug(verified);
+    return verified;
   } catch (error) {
     debug(error);
     throw new AccessDeniedException("Unverified");

--- a/src/routes/BaseRoutes.ts
+++ b/src/routes/BaseRoutes.ts
@@ -29,13 +29,14 @@ export default {
     const authorization = context.request.headers.authorization;
     const authorizationContext = context.request.headers["x-authorization-context"];
     const consentToken = context.request.headers["x-consent-token"];
-    await Authorizator.authorize(authorization, authorizationContext, consentToken); // Throws AccessDeniedException if access needs to be denied
+    const response = await Authorizator.authorize(authorization, authorizationContext, consentToken); // Throws AccessDeniedException if access needs to be denied
 
     return {
       statusCode: 200,
       headers: getJSONResponseHeaders(),
       body: JSON.stringify({
         message: "Access Granted",
+        ...response,
       }),
     };
   },

--- a/src/routes/BaseRoutes.ts
+++ b/src/routes/BaseRoutes.ts
@@ -34,10 +34,7 @@ export default {
     return {
       statusCode: 200,
       headers: getJSONResponseHeaders(),
-      body: JSON.stringify({
-        message: "Access Granted",
-        ...response,
-      }),
+      body: JSON.stringify(response),
     };
   },
   // openapi-backend special handlers

--- a/src/utils/Authorizator.ts
+++ b/src/utils/Authorizator.ts
@@ -4,7 +4,7 @@ import * as TestbedAuthorizer from "../providers/testbed/TestbedAuthorizer";
 import { AccessDeniedException } from "./exceptions";
 import { decodeIdToken } from "./JWK-Utils";
 import { omitEmptyObjectKeys } from "./transformers";
-import { AuthorizationHeaders, Authorizer } from "./types";
+import { AuthorizationHeaders, Authorizer, AuthorizerResponse } from "./types";
 
 /**
  * Resolve authorization provider from authorization header
@@ -50,7 +50,7 @@ export default {
    * @param authData
    * @returns
    */
-  async authorize(authorization: string | string[], authorizationContext: string | string[], consentToken: string | string[]): Promise<void> {
+  async authorize(authorization: string | string[], authorizationContext: string | string[], consentToken: string | string[]): Promise<AuthorizerResponse> {
     const authHeaders = omitEmptyObjectKeys({
       authorization: String(authorization),
       context: authorizationContext ? String(authorizationContext) : "",

--- a/src/utils/Authorizator.ts
+++ b/src/utils/Authorizator.ts
@@ -1,9 +1,9 @@
-import { debug } from "console";
 import * as SinunaAuthorizer from "../providers/sinuna/SinunaAuthorizer";
 import * as SuomiFIAuthorizer from "../providers/suomifi/SuomiFIAuthorizer";
 import * as TestbedAuthorizer from "../providers/testbed/TestbedAuthorizer";
 import { AccessDeniedException } from "./exceptions";
 import { decodeIdToken } from "./JWK-Utils";
+import { debug } from "./logging";
 import { omitEmptyObjectKeys } from "./transformers";
 import { AuthorizationHeaders, Authorizer, AuthorizerResponse } from "./types";
 

--- a/src/utils/Authorizator.ts
+++ b/src/utils/Authorizator.ts
@@ -1,3 +1,4 @@
+import { debug } from "console";
 import * as SinunaAuthorizer from "../providers/sinuna/SinunaAuthorizer";
 import * as SuomiFIAuthorizer from "../providers/suomifi/SuomiFIAuthorizer";
 import * as TestbedAuthorizer from "../providers/testbed/TestbedAuthorizer";
@@ -18,7 +19,9 @@ function resolveAuthProvider(authorization: string): string {
     if (typeof result.decodedToken?.payload === "object" && typeof result.decodedToken.payload?.iss === "string") {
       return result.decodedToken.payload.iss;
     }
-  } catch (error) {}
+  } catch (error) {
+    debug(error);
+  }
   throw new AccessDeniedException("Invalid authorization header");
 }
 

--- a/src/utils/JWK-Utils.ts
+++ b/src/utils/JWK-Utils.ts
@@ -2,6 +2,8 @@
 
 import axios from "axios";
 import * as jwt from "jsonwebtoken";
+import { decode as jwtDecode } from 'jsonwebtoken'; // @see: https://github.com/auth0/node-jsonwebtoken/issues/875#issuecomment-1375779641
+
 import jwktopem from "jwk-to-pem";
 import { Context } from "openapi-backend";
 import CacheService from "./CacheService";
@@ -42,7 +44,7 @@ export function decodeIdToken(idToken: string | null): { decodedToken: jwt.Jwt |
   }
 
   const token = parseAuthorizationHeaderValue(idToken);
-  const decodedToken = jwt.decode(token, { complete: true });
+  const decodedToken = jwtDecode(token, { complete: true });
   return {
     decodedToken: decodedToken,
     token: token,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -89,7 +89,7 @@ export type Authorizer = {
   isMatchingProvider: (provider: string) => boolean;
 };
 
-export type AuthorizerResponse = { message?: string; authorization: JwtPayload | null; consent: JwtPayload | null };
+export type AuthorizerResponse = { message: string; authorization: JwtPayload | null; consent?: JwtPayload | null };
 
 export type AuthorizationHeaders = {
   authorization: string;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,3 +1,4 @@
+import { JwtPayload } from "jsonwebtoken";
 import { Context } from "openapi-backend";
 
 export type AppContext = {
@@ -80,13 +81,15 @@ export type Authorizer = {
    * @param token
    * @throws AccessDeniedException - if access is denied
    */
-  authorize: (authorizationHeaders: AuthorizationHeaders) => Promise<void>;
+  authorize: (authorizationHeaders: AuthorizationHeaders) => Promise<AuthorizerResponse>;
 
   /**
    * Matches the provider to the authorizer
    */
   isMatchingProvider: (provider: string) => boolean;
 };
+
+export type AuthorizerResponse = { message?: string; authorization: JwtPayload | null; consent: JwtPayload | null };
 
 export type AuthorizationHeaders = {
   authorization: string;

--- a/webapps/svelte/src/lib/api/openapi/generated/services/DefaultService.ts
+++ b/webapps/svelte/src/lib/api/openapi/generated/services/DefaultService.ts
@@ -69,6 +69,8 @@ export class DefaultService {
         xConsentToken?: string,
     }): CancelablePromise<{
         message?: string;
+        authorization?: any;
+        consent?: any;
     }> {
         return this.httpRequest.request({
             method: 'POST',

--- a/webapps/svelte/src/lib/api/openapi/generated/services/DefaultService.ts
+++ b/webapps/svelte/src/lib/api/openapi/generated/services/DefaultService.ts
@@ -68,8 +68,8 @@ export class DefaultService {
          */
         xConsentToken?: string,
     }): CancelablePromise<{
-        message?: string;
-        authorization?: any;
+        message: string;
+        authorization: any;
         consent?: any;
     }> {
         return this.httpRequest.request({


### PR DESCRIPTION
- /authorize endpoint returns the token payloads
- can be used for example to verify the consent token idp/data source value
- upgrade the jsonwebtoken to v9 for security fixes