### PR TITLE
feat: login and logout redirection messages now in unified structure

### DIFF
--- a/docs/frontend-app-usage.md
+++ b/docs/frontend-app-usage.md
@@ -66,12 +66,13 @@ The login code is either a temporary code that can be exchanged for authenticati
 
 If login fails / the attempt is cancelled etc, the user is redirected to the `redirectUrl` with a query parameters package:
 
-- `error`: the error message
+- `success=0`, int-boolean, `0` if login fails, `1` on success
+- `message`: the error message
 - `type`: message type, one of `danger`, `warning`, `info`
 - `provider`: authentication provider, eg. `sinuna`
-- `intent=AuthenticationRequest`: intent of the request, with a login situation its always `AuthenticationRequest`
+- `event=login`: intent of the request, with a login situation its always `login`
 
-eg: `https://${frontendAppHost}/login-handler.html?error=Authentication+cancelled&type=info&provider=sinuna&intent=AuthenticationRequest`
+eg: `https://${frontendAppHost}/login-handler.html?success=0&message=Authentication+failed&type=info&provider=sinuna&intent=login`
 
 ## LoginRequest
 
@@ -140,9 +141,10 @@ eg: `https://${frontendAppHost}/login-handler.html?logout=success&provider=sinun
 
 If logout fails / user is already logged out etc, the user is redirected to the `redirectUrl` with with a query parameters package:
 
-- `error`: the error message
+- `success=0`: int-boolean, `0` if logout fails, `1` on success
+- `message`: the error message
 - `type`: message type, one of `danger`, `warning`, `info`
 - `provider`: authentication provider, eg. `sinuna`
-- `intent=LogoutRequest`: intent of the request, with a logout situation its always `LogoutRequest`
+- `event=logout`: intent of the request, with a logout situation its always `logout`
 
-eg: `https://${frontendAppHost}/login-handler.html?error=Already+logged+out&type=info&provider=sinuna&intent=LogoutRequest`
+eg: `https://${frontendAppHost}/login-handler.html?success=0&message=Logout+failed&type=info&provider=sinuna&intent=event`

--- a/docs/frontend-app-usage.md
+++ b/docs/frontend-app-usage.md
@@ -66,13 +66,13 @@ The login code is either a temporary code that can be exchanged for authenticati
 
 If login fails / the attempt is cancelled etc, the user is redirected to the `redirectUrl` with a query parameters package:
 
-- `success=false`, boolean, `false` if login fails, `true` on success
+- `success=false`, string-boolean, `false` if login fails, `true` on success
 - `message`: the error message
 - `type`: message type, one of `danger`, `warning`, `info`
 - `provider`: authentication provider, eg. `sinuna`
 - `event=login`: intent of the request, with a login situation its always `login`
 
-eg: `https://${frontendAppHost}/login-handler.html?success=0&message=Authentication+failed&type=info&provider=sinuna&intent=login`
+eg: `https://${frontendAppHost}/login-handler.html?success=false&message=Authentication+failed&type=info&provider=sinuna&intent=login`
 
 ## LoginRequest
 
@@ -141,10 +141,10 @@ eg: `https://${frontendAppHost}/login-handler.html?logout=success&provider=sinun
 
 If logout fails / user is already logged out etc, the user is redirected to the `redirectUrl` with with a query parameters package:
 
-- `success=false`, boolean, `false` if login fails, `true` on success
+- `success=false`, string-boolean, `false` if login fails, `true` on success
 - `message`: the error message
 - `type`: message type, one of `danger`, `warning`, `info`
 - `provider`: authentication provider, eg. `sinuna`
 - `event=logout`: intent of the request, with a logout situation its always `logout`
 
-eg: `https://${frontendAppHost}/login-handler.html?success=0&message=Logout+failed&type=info&provider=sinuna&intent=event`
+eg: `https://${frontendAppHost}/login-handler.html?success=false&message=Logout+failed&type=info&provider=sinuna&intent=event`

--- a/docs/frontend-app-usage.md
+++ b/docs/frontend-app-usage.md
@@ -66,7 +66,7 @@ The login code is either a temporary code that can be exchanged for authenticati
 
 If login fails / the attempt is cancelled etc, the user is redirected to the `redirectUrl` with a query parameters package:
 
-- `success=0`, int-boolean, `0` if login fails, `1` on success
+- `success=false`, boolean, `false` if login fails, `true` on success
 - `message`: the error message
 - `type`: message type, one of `danger`, `warning`, `info`
 - `provider`: authentication provider, eg. `sinuna`
@@ -141,7 +141,7 @@ eg: `https://${frontendAppHost}/login-handler.html?logout=success&provider=sinun
 
 If logout fails / user is already logged out etc, the user is redirected to the `redirectUrl` with with a query parameters package:
 
-- `success=0`: int-boolean, `0` if logout fails, `1` on success
+- `success=false`, boolean, `false` if login fails, `true` on success
 - `message`: the error message
 - `type`: message type, one of `danger`, `warning`, `info`
 - `provider`: authentication provider, eg. `sinuna`

--- a/src/providers/sinuna/SinunaRequestHandler.ts
+++ b/src/providers/sinuna/SinunaRequestHandler.ts
@@ -129,6 +129,7 @@ export default new (class SinunaRequestHandler extends BaseRequestHandler implem
       const parsedAppContext = parseAppContext(context, { provider: this.identityProviderIdent });
       const LOGOUT_CALLBACK_REDIRECT_URI = Runtime.getAppUrl("/auth/openid/sinuna/logout-response");
       const LOGOUT_REQUEST_URL = `https://login.iam.qa.sinuna.fi/oxauth/restv1/end_session?post_logout_redirect_uri=${LOGOUT_CALLBACK_REDIRECT_URI}`;
+      
 
       return {
         statusCode: 303,
@@ -138,7 +139,7 @@ export default new (class SinunaRequestHandler extends BaseRequestHandler implem
         cookies: [prepareCookie("appContext", parsedAppContext.hash)],
       };
     } catch (error) {
-      return this.getLogoutRequestFailedResponse(context, error);
+      return this.getLogoutRequestFailedResponse(context, error, { success: "1" });
     }
   }
 

--- a/src/providers/sinuna/SinunaRequestHandler.ts
+++ b/src/providers/sinuna/SinunaRequestHandler.ts
@@ -139,7 +139,7 @@ export default new (class SinunaRequestHandler extends BaseRequestHandler implem
         cookies: [prepareCookie("appContext", parsedAppContext.hash)],
       };
     } catch (error) {
-      return this.getLogoutRequestFailedResponse(context, error, { success: "1" });
+      return this.getLogoutRequestFailedResponse(context, error, { success: true });
     }
   }
 

--- a/src/providers/suomifi/SuomiFIRequestHandler.ts
+++ b/src/providers/suomifi/SuomiFIRequestHandler.ts
@@ -7,7 +7,7 @@ import { BaseRequestHandler } from "../../utils/BaseRequestHandler";
 import { getJSONResponseHeaders } from "../../utils/default-headers";
 import { AccessDeniedException, NoticeException, ValidationError } from "../../utils/exceptions";
 import { debug, log } from "../../utils/logging";
-import { prepareCookie, prepareLoginRedirectUrl, prepareLogoutErrorRedirectUrl, prepareLogoutRedirectUrl } from "../../utils/route-utils";
+import { prepareCookie, prepareLoginRedirectUrl, prepareLogoutRedirectUrl } from "../../utils/route-utils";
 import { parseBase64XMLBody } from "../../utils/transformers";
 
 import { AuthRequestHandler, HttpResponse } from "../../utils/types";
@@ -179,7 +179,7 @@ export default new (class SuomiFIRequestHandler extends BaseRequestHandler imple
       await samlClient.validateRedirectAsync(body, originalQuery); // throws
     } catch (error) {
       log("LogoutResponse", error);
-      logoutRedirectUrl = prepareLogoutErrorRedirectUrl(logoutRedirectUrl, { error: "Logout session could not be ended", type: "info", provider: this.identityProviderIdent });
+      logoutRedirectUrl = prepareLogoutRedirectUrl(logoutRedirectUrl, this.identityProviderIdent, { message: "Suboptimal logout validation response", type: "warning"});
     }
 
     return {

--- a/src/providers/testbed/TestbedRequestHandler.ts
+++ b/src/providers/testbed/TestbedRequestHandler.ts
@@ -166,7 +166,7 @@ export default new (class TestbedRequestHandler extends BaseRequestHandler imple
         cookies: [prepareCookie("appContext", parsedAppContext.hash)],
       };
     } catch (error) {
-      return this.getLogoutRequestFailedResponse(context, error, { success: "1" });
+      return this.getLogoutRequestFailedResponse(context, error, { success: true });
     }
   }
 

--- a/src/providers/testbed/TestbedRequestHandler.ts
+++ b/src/providers/testbed/TestbedRequestHandler.ts
@@ -166,7 +166,7 @@ export default new (class TestbedRequestHandler extends BaseRequestHandler imple
         cookies: [prepareCookie("appContext", parsedAppContext.hash)],
       };
     } catch (error) {
-      return this.getLogoutRequestFailedResponse(context, error);
+      return this.getLogoutRequestFailedResponse(context, error, { success: "1" });
     }
   }
 

--- a/src/utils/BaseRequestHandler.ts
+++ b/src/utils/BaseRequestHandler.ts
@@ -3,7 +3,7 @@ import { Context } from "openapi-backend";
 import { AccessDeniedException, NoticeException } from "./exceptions";
 import { debug } from "./logging";
 import { prepareCookie, prepareLoginErrorRedirectUrl, prepareLogoutErrorRedirectUrl } from "./route-utils";
-import { HttpResponse, IBaseRequestHandler, NotifyErrorType } from "./types";
+import { HttpResponse, IBaseRequestHandler, NotifyType, RedirectMessage } from "./types";
 import { parseAppContext } from "./validators";
 
 export abstract class BaseRequestHandler implements IBaseRequestHandler {
@@ -25,7 +25,7 @@ export abstract class BaseRequestHandler implements IBaseRequestHandler {
     debug(error);
 
     let errorMessage = "Authentication failed";
-    let errorType: NotifyErrorType = "danger";
+    let errorType: NotifyType = "danger";
 
     if (error instanceof NoticeException) {
       errorMessage = error.message;
@@ -40,7 +40,7 @@ export abstract class BaseRequestHandler implements IBaseRequestHandler {
 
     const parsedAppContext = parseAppContext(context, { provider: this.identityProviderIdent }); // throws
     const redirectUrl = prepareLoginErrorRedirectUrl(parsedAppContext.object.redirectUrl, {
-      error: errorMessage,
+      message: errorMessage,
       provider: this.identityProviderIdent,
       type: errorType,
     });
@@ -59,14 +59,15 @@ export abstract class BaseRequestHandler implements IBaseRequestHandler {
    *
    * @param context
    * @param error
-   * @param errorTypeOverride - override error type
+   * @param message - override message
    * @returns
    */
-  async getLogoutRequestFailedResponse(context: Context | string, error: any, errorTypeOverride?: NotifyErrorType): Promise<HttpResponse> {
+  async getLogoutRequestFailedResponse(context: Context | string, error: any, message?: RedirectMessage): Promise<HttpResponse> {
     debug(error);
 
     let errorMessage = "Logout failed";
-    let errorType: NotifyErrorType = "danger";
+    let errorType: NotifyType = "danger";
+    let success: RedirectMessage["success"] = "0";
 
     if (error instanceof NoticeException) {
       errorMessage = error.message;
@@ -76,15 +77,20 @@ export abstract class BaseRequestHandler implements IBaseRequestHandler {
       errorType = "warning";
     }
 
-    if (typeof errorTypeOverride !== "undefined") {
-      errorType = errorTypeOverride;
-    }
+    if (message && message.type) {
+      errorType = message.type;
+    } 
+    if (message && typeof message.success !== "undefined") {
+      success = message.success;
+    } 
+
 
     const parsedAppContext = parseAppContext(context, { provider: this.identityProviderIdent }); // throws
     const redirectUrl = prepareLogoutErrorRedirectUrl(parsedAppContext.object.redirectUrl, {
-      error: errorMessage,
+      success: success,
       provider: this.identityProviderIdent,
       type: errorType,
+      message: errorMessage,
     });
 
     return {

--- a/src/utils/BaseRequestHandler.ts
+++ b/src/utils/BaseRequestHandler.ts
@@ -67,7 +67,7 @@ export abstract class BaseRequestHandler implements IBaseRequestHandler {
 
     let errorMessage = "Logout failed";
     let errorType: NotifyType = "danger";
-    let success: RedirectMessage["success"] = "0";
+    let success: RedirectMessage["success"] = false;
 
     if (error instanceof NoticeException) {
       errorMessage = error.message;

--- a/src/utils/route-utils.ts
+++ b/src/utils/route-utils.ts
@@ -28,10 +28,10 @@ export function prepareRedirectUrl(redirectUrl: string, providerIdent: string, p
  * @returns 
  */
 export function prepareLoginRedirectUrl(redirectUrl: string, loginCode: string, providerIdent: string, message?: RedirectMessage): string {
-  const params: Array<{key: string, value: string | undefined}> = [
+  const params: Array<{key: string, value: string | undefined | boolean}> = [
     { key: "loginCode", value: loginCode },
     { key: "provider", value: providerIdent },
-    { key: "success", value: "1"},
+    { key: "success", value: true},
     { key: "event", value: "login"},
   ];
 
@@ -51,8 +51,8 @@ export function prepareLoginRedirectUrl(redirectUrl: string, loginCode: string, 
  * @returns 
  */
 export function prepareLogoutRedirectUrl(redirectUrl: string, providerIdent: string, message?: RedirectMessage): string {
-  const params: Array<{key: string, value: string | undefined}> = [
-    { key: "success", value: "1"},
+  const params: Array<{key: string, value: string | undefined | boolean}> = [
+    { key: "success", value: true},
     { key: "event", value: "logout" },
     { key: "provider", value: providerIdent },
     { key: "logout", value: "success" } // @obsolete
@@ -75,7 +75,7 @@ export function prepareLogoutRedirectUrl(redirectUrl: string, providerIdent: str
  */
 export function prepareErrorRedirectUrl(redirectUrl: string, message: RedirectMessage): string {
   return ensureUrlQueryParams(redirectUrl, [
-    { key: "success", value: "0"},
+    { key: "success", value: false},
     { key: "message", value: message.message },
     { key: "provider", value: message.provider || "unknown" },
     { key: "event", value: message.event },

--- a/src/utils/route-utils.ts
+++ b/src/utils/route-utils.ts
@@ -6,7 +6,7 @@ import { AccessDeniedException, ValidationError } from "../utils/exceptions";
 import { debug, log } from "../utils/logging";
 import { ensureArray, ensureUrlQueryParams, exceptionToObject } from "../utils/transformers";
 import { getJSONResponseHeaders } from "./default-headers";
-import { NotifyErrorType } from "./types";
+import { RedirectMessage } from "./types";
 import { parseAppContext } from "./validators";
 
 /**
@@ -20,30 +20,50 @@ export function prepareRedirectUrl(redirectUrl: string, providerIdent: string, p
 }
 
 /**
- *
- * @param redirectUrl
- * @param loginCode
- * @param providerIdent
- * @returns
+ * 
+ * @param redirectUrl 
+ * @param loginCode 
+ * @param providerIdent 
+ * @param message 
+ * @returns 
  */
-export function prepareLoginRedirectUrl(redirectUrl: string, loginCode: string, providerIdent: string): string {
-  return ensureUrlQueryParams(redirectUrl, [
+export function prepareLoginRedirectUrl(redirectUrl: string, loginCode: string, providerIdent: string, message?: RedirectMessage): string {
+  const params: Array<{key: string, value: string | undefined}> = [
     { key: "loginCode", value: loginCode },
     { key: "provider", value: providerIdent },
-  ]);
+    { key: "success", value: "1"},
+    { key: "event", value: "login"},
+  ];
+
+  if (message) {
+    params.push({ key: "message", value: message.message });
+    params.push({ key: "type", value: message.type });
+  }
+
+  return ensureUrlQueryParams(redirectUrl, params);
 }
 
 /**
- *
- * @param redirectUrl
- * @param providerIdent
- * @returns
+ * 
+ * @param redirectUrl 
+ * @param providerIdent 
+ * @param message 
+ * @returns 
  */
-export function prepareLogoutRedirectUrl(redirectUrl: string, providerIdent: string): string {
-  return ensureUrlQueryParams(redirectUrl, [
-    { key: "logout", value: "success" },
+export function prepareLogoutRedirectUrl(redirectUrl: string, providerIdent: string, message?: RedirectMessage): string {
+  const params: Array<{key: string, value: string | undefined}> = [
+    { key: "success", value: "1"},
+    { key: "event", value: "logout" },
     { key: "provider", value: providerIdent },
-  ]);
+    { key: "logout", value: "success" } // @obsolete
+  ];
+
+  if (message) {
+    params.push({ key: "message", value: message.message });
+    params.push({ key: "type", value: message.type });
+  }
+
+  return ensureUrlQueryParams(redirectUrl, params);
 }
 
 /**
@@ -53,11 +73,12 @@ export function prepareLogoutRedirectUrl(redirectUrl: string, providerIdent: str
  * @param providerIdent
  * @returns
  */
-export function prepareErrorRedirectUrl(redirectUrl: string, message: { error: string; provider?: string; intent: string; type: NotifyErrorType }): string {
+export function prepareErrorRedirectUrl(redirectUrl: string, message: RedirectMessage): string {
   return ensureUrlQueryParams(redirectUrl, [
-    { key: "error", value: message.error },
+    { key: "success", value: "0"},
+    { key: "message", value: message.message },
     { key: "provider", value: message.provider || "unknown" },
-    { key: "intent", value: message.intent },
+    { key: "event", value: message.event },
     { key: "type", value: message.type },
   ]);
 }
@@ -68,11 +89,11 @@ export function prepareErrorRedirectUrl(redirectUrl: string, message: { error: s
  * @param message
  * @returns
  */
-export function prepareLoginErrorRedirectUrl(redirectUrl: string, message: { error: string; provider?: string; type: NotifyErrorType }): string {
+export function prepareLoginErrorRedirectUrl(redirectUrl: string, message: RedirectMessage): string {
   return prepareErrorRedirectUrl(redirectUrl, {
-    error: message.error,
+    message: message.message,
     provider: message.provider,
-    intent: "LoginRequest",
+    event: "login",
     type: message.type,
   });
 }
@@ -83,11 +104,11 @@ export function prepareLoginErrorRedirectUrl(redirectUrl: string, message: { err
  * @param message
  * @returns
  */
-export function prepareLogoutErrorRedirectUrl(redirectUrl: string, message: { error: string; provider?: string; type: NotifyErrorType }): string {
+export function prepareLogoutErrorRedirectUrl(redirectUrl: string, message: RedirectMessage): string {
   return prepareErrorRedirectUrl(redirectUrl, {
-    error: message.error,
+    message: message.message,
     provider: message.provider,
-    intent: "LogoutRequest",
+    event: "logout",
     type: message.type,
   });
 }

--- a/src/utils/transformers.ts
+++ b/src/utils/transformers.ts
@@ -123,9 +123,10 @@ export function ensureArray(value: any): any[] {
  * @param value
  * @returns
  */
-export function ensureUrlQueryParam(url: string, key: string, value: string | undefined): string {
+export function ensureUrlQueryParam(url: string, key: string, value: string | undefined | boolean): string {
   const urlObj = new URL(url);
-  urlObj.searchParams.set(key, typeof value !== "undefined" ? value : "");
+  const parsedValue = typeof value === "boolean" ? (value ? "true" : "false") : typeof value !== "undefined" ? value : "";
+  urlObj.searchParams.set(key, parsedValue);
   return urlObj.toString();
 }
 
@@ -135,7 +136,7 @@ export function ensureUrlQueryParam(url: string, key: string, value: string | un
  * @param params
  * @returns
  */
-export function ensureUrlQueryParams(url: string, params: Array<{ key: string; value: string | undefined }>): string {
+export function ensureUrlQueryParams(url: string, params: Array<{ key: string; value: string | undefined | boolean }>): string {
   for (const group of params) {
     url = ensureUrlQueryParam(url, group.key, group.value);
   }

--- a/src/utils/transformers.ts
+++ b/src/utils/transformers.ts
@@ -123,9 +123,9 @@ export function ensureArray(value: any): any[] {
  * @param value
  * @returns
  */
-export function ensureUrlQueryParam(url: string, key: string, value: string): string {
+export function ensureUrlQueryParam(url: string, key: string, value: string | undefined): string {
   const urlObj = new URL(url);
-  urlObj.searchParams.set(key, value);
+  urlObj.searchParams.set(key, typeof value !== "undefined" ? value : "");
   return urlObj.toString();
 }
 
@@ -135,7 +135,7 @@ export function ensureUrlQueryParam(url: string, key: string, value: string): st
  * @param params
  * @returns
  */
-export function ensureUrlQueryParams(url: string, params: Array<{ key: string; value: string }>): string {
+export function ensureUrlQueryParams(url: string, params: Array<{ key: string; value: string | undefined }>): string {
   for (const group of params) {
     url = ensureUrlQueryParam(url, group.key, group.value);
   }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -106,7 +106,7 @@ export interface IBaseRequestHandler {
 }
 
 export type RedirectMessage = { 
-  success?: "0" | "1", 
+  success?: boolean, 
   message?: string; 
   provider?: string; 
   type?: NotifyType,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -25,7 +25,7 @@ export type HttpResponse = {
 /**
  * Output error message level
  */
-export type NotifyErrorType = "info" | "warning" | "danger";
+export type NotifyType = "info" | "warning" | "danger";
 
 export interface AuthRequestHandler {
   /**
@@ -101,6 +101,14 @@ export interface IBaseRequestHandler {
   identityProviderIdent: string;
   initialize(): Promise<void>;
   getAuthenticateResponseFailedResponse(context: Context, error: any): Promise<HttpResponse>;
-  getLogoutRequestFailedResponse(context: Context | string, error: any, errorTypeOverride?: NotifyErrorType): Promise<HttpResponse>;
+  getLogoutRequestFailedResponse(context: Context | string, error: any, message?: RedirectMessage): Promise<HttpResponse>;
   [attr: string]: any;
+}
+
+export type RedirectMessage = { 
+  success?: "0" | "1", 
+  message?: string; 
+  provider?: string; 
+  type?: NotifyType,
+  event?: string, 
 }

--- a/webapps/svelte/src/lib/app/LoginEventListener.ts
+++ b/webapps/svelte/src/lib/app/LoginEventListener.ts
@@ -5,7 +5,7 @@ export default async function LoginEventListener(loginApp: LoginApp) {
   const provider = urlParams.get("provider");
   const loginCode = urlParams.get("loginCode");
   const event = urlParams.get("event");
-  const success = urlParams.get("success");
+  const success = urlParams.get("success") === "true";
   
   const affectsThisApp = provider && provider.toLowerCase() === loginApp.getName().toLowerCase();
 


### PR DESCRIPTION
- update how the authentication redirect situational event messages are formed
    - all redirection messages now in unified structure

New redirect query params:

- Login success:
    - event=login 
    - success=true
    - provider=testbed
    - loginCode=12345
    - (message: login message)
    - (type: message type)
- Login error:
    - event=login 
    - success=false
    - message=error message 
    - type=danger
    - provider=testbed
 - Logout success:
    - event=logout
    - success=true
    - provider=testbed
    - (message: logout message)
    - (type: message type)
- Logout error:
    - event=logout
    - success=false
    - message=error message 
    - type=danger
    - provider=testbed

Old redirect query params:

- Login success:
    - loginCode=12345
    - provider=testbed
 - Login error:
    - intent=AuthenticationRequest 
    - error=error message
    - type=danger
    - provider=testbed
- Logout success:
    - logout=success
    - provider=testbed
- Logout error:
    - intent=LogoutRequest
    - error=error message
    - type=danger
    - provider=testbed
    